### PR TITLE
Added setup.py file for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="gnss-ins-sim",
+    version="2.1",
+    author="Aceinna",
+    author_email="xgdong@aceinna.com",
+    description="GNSS-INS-SIM is an GNSS/INS simulation project, "
+        "which generates reference trajectories, IMU sensor output, "
+        "GPS output, odometer output and magnetometer output.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Aceinna/gnss-ins-sim",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)


### PR DESCRIPTION
It'd be nice to make this package pip installable. I've added a boiler plate `setup.py` file. Please feel free to edit any fields that you think needs to be changed, namely: version, author, author_email, or classifiers.

With this change, anyone who clones the repo can simply run `pip install -e <path_to_repo_root>` to install the package to their local python environment (or virtualenv).