### PR TITLE
Bug fixes in attitude.py & ins_sim.py

### DIFF
--- a/demo_gen_data_from_files.py
+++ b/demo_gen_data_from_files.py
@@ -31,7 +31,7 @@ def gen_data_first(data_dir):
     # start simulation
     sim = ins_sim.Sim([fs, fs_gps, fs_mag],
                       motion_def_path+"//motion_def-90deg_turn.csv",
-                      ref_frame=1,
+                      ref_frame=0,
                       imu=imu,
                       mode=None,
                       env=None,
@@ -72,15 +72,14 @@ def test_gen_data_from_files(data_dir):
                       imu=None,
                       mode=None,
                       env=None,
-                      algorithm=None)
+                      algorithm=algo)
     # run the simulation for 1000 times
     sim.run(1)
     # generate simulation results, summary
-    # do not save data since the simulation runs for 1000 times and generates too many results
     sim.results('', err_stats_start=-1, gen_kml=True)
     sim.plot(['att_euler'])
 
 if __name__ == '__main__':
-    dir_of_logged_files = "E://Projects//python-imu380-mult//ins_data//"
-    # gen_data_first(dir_of_logged_files)
+    dir_of_logged_files = os.path.abspath('.//demo_saved_data//tmp//')
+    gen_data_first(dir_of_logged_files)
     test_gen_data_from_files(dir_of_logged_files)

--- a/gnss_ins_sim/attitude/attitude.py
+++ b/gnss_ins_sim/attitude/attitude.py
@@ -66,7 +66,7 @@ def quat_conj(q):
     Returns:
         qc: quaternion conjugate
     """
-    qc = q
+    qc = q.copy()
     qc[1] = -q[1]
     qc[2] = -q[2]
     qc[3] = -q[3]

--- a/gnss_ins_sim/attitude/attitude.py
+++ b/gnss_ins_sim/attitude/attitude.py
@@ -70,6 +70,7 @@ def quat_conj(q):
     qc[1] = -q[1]
     qc[2] = -q[2]
     qc[3] = -q[3]
+    return qc
 
 def quat_multiply(q1, q2):
     """

--- a/gnss_ins_sim/sim/ins_sim.py
+++ b/gnss_ins_sim/sim/ins_sim.py
@@ -616,7 +616,7 @@ class Sim(object):
                     mobility = high_mobility
             elif isinstance(mode, np.ndarray):      # customize the sim mode
                 if mode.shape == (3,):
-                    mobility = mode
+                    mobility = mode.copy()
                     mobility[1] = mobility[1] * attitude.D2R
                     mobility[2] = mobility[2] * attitude.D2R
                 else:


### PR DESCRIPTION
Two minor fixes:
- Fix 1: [attitude/quat_conj()](https://github.com/Aceinna/gnss-ins-sim/blob/e479c8ca83630008cd11c44a2bd2ce6727a2d35e/gnss_ins_sim/attitude/attitude.py#L61) now returns the quaternion conjugate as indicated by docstring, instead of nothing. (The function is not used anywhere in the project.)
- Fix 2: [Sim.__parse_mode()](https://github.com/Aceinna/gnss-ins-sim/blob/e479c8ca83630008cd11c44a2bd2ce6727a2d35e/gnss_ins_sim/sim/ins_sim.py#L600) no longer modifies the ndarray referenced by 'mode'. (Previously when running consecutive simulations using the same 'mode' ndarray the unit conversion caused angular rate and angular acceleration limits to decrease each time.) 