### PR TITLE
Now data files are installed too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Aceinna/gnss-ins-sim",
+    install_requires=['numpy>1.10', 'matplotlib'],
     packages=setuptools.find_packages(),
     package_data={"": ['*.COF']},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/Aceinna/gnss-ins-sim",
     packages=setuptools.find_packages(),
+    package_data={"": ['*.COF']},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
In your install script you forgot to include the .COF files. So after I installed the package, I can not use it from another project, as when I try to run a simulation it throws me a error, similar to:
FileNotFoundError: [Errno 2] No such file or directory: '.../venv/lib/python3.6/site-packages/gnss_ins_sim-2.1-py3.6.egg/gnss_ins_sim/geoparams/WMM.COF'

So I just included these files into your setup script. With this addition everything setups properly and works out of the box